### PR TITLE
MFN News Feed - Date format translation update

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -147,6 +147,7 @@ function upsertLanguage($post_id, $groupId, $lang)
 
 function upsertItem($item, $signature = '', $raw_data = '', $reset_cache = false)
 {
+    do_action('mfn_before_upsertitem', $item);
     global $wpdb;
 
     $newsid = $item->news_id;
@@ -215,6 +216,9 @@ LIMIT 1
         }
         $outro($post_id);
     }
+
+    // run callback
+    do_action('mfn_after_upsertitem', $post_id);
 
     return 1;
 }

--- a/posthook.php
+++ b/posthook.php
@@ -86,6 +86,8 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST')
     $signature = $_SERVER['HTTP_X_HUB_SIGNATURE'];
     $content = file_get_contents("php://input");
 
+    do_action( 'mfn_before_posthook', $content);
+
     $verify_signature =  isset($ops['verify_signature']) ? $ops['verify_signature'] : 'off';
     $reset_cache =  isset($ops['reset_cache']) ? ($ops['reset_cache'] == 'on') : false;
 
@@ -106,4 +108,6 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST')
 
     $news_item = json_decode($content);
     upsertItem($news_item, $signature, $content, $reset_cache);
+    do_action( 'mfn_after_posthook', $news_item);
+
 }

--- a/widgets.php
+++ b/widgets.php
@@ -751,9 +751,9 @@ class mfn_news_feed_widget extends WP_Widget
         echo "<div class=\"mfn-list\">";
 
         foreach ($res as $item) {
-            $date = date_create($item->post_date_gmt . "Z");
-            $date = date_timezone_set($date, new DateTimeZone($tzLocation));
-            $datestr = date_format($date, $timestampFormat);
+            $date = new DateTime($item->post_date_gmt . "Z");
+            $date->setTimezone(new DateTimeZone($tzLocation));
+            $datestr = date_i18n($timestampFormat,$date->getTimestamp() + $date->getOffset());
 
             $tags = "";
             foreach ($item->tags as $tag) {


### PR DESCRIPTION
- MFN News Feed - Updated date format to automatically translate to the current WP-language
- Also added actions (do_action): _mfn_before_upsertitem_, _mfn_after_upsertitem_, _mfn_before_posthook_, _mfn_after_posthook_ to make it possible to add own action callbacks to run at these events