### PR TITLE
MFN News Feed Widget: Hotfixes

### DIFF
--- a/api.php
+++ b/api.php
@@ -125,6 +125,10 @@ function MFN_get_reports($lang = 'all', $offset = 0, $limit = 100, $order = 'DES
 
     $params = array();
 
+    $slug_prefix = (MFN_TAG_PREFIX !== '' && MFN_TAG_PREFIX !== null ? MFN_TAG_PREFIX . '-' : '');
+    $annual_slug = $slug_prefix . 'report-annual';
+    $interim_slug = $slug_prefix . 'report-interim';
+
     $query = "
         SELECT posts.ID post_id,
                posts.post_date_gmt date_gmt,
@@ -147,12 +151,12 @@ function MFN_get_reports($lang = 'all', $offset = 0, $limit = 100, $order = 'DES
             LEFT JOIN $wpdb->postmeta meta
                 ON posts.ID = meta.post_id AND meta.meta_key = '" . MFN_POST_TYPE . "_attachment_data'
             WHERE (
-                t.slug = 'mfn-report-annual'
-                OR t.slug = 'mfn-report-interim'
-                OR t.slug like 'mfn-report-annual_%'
-                OR t.slug like 'mfn-report-interim_%'
+                t.slug = '" . $annual_slug . "'
+                OR t.slug = '" . $interim_slug . "'
+                OR t.slug like '" . $annual_slug . "_%'
+                OR t.slug like '" . $interim_slug . "_%'
             )
-            AND tax.taxonomy = 'mfn-news-tag'
+            AND tax.taxonomy = '" . MFN_TAXONOMY_NAME . "'
     ";
 
     if($lang !== "all") {

--- a/config.php
+++ b/config.php
@@ -330,7 +330,7 @@ function sync_mfn_taxonomy()
         $wpdb->update(
             $tbmlTranslations,
             array('language_code' => 'en', 'source_language_code' => null),
-            array('element_id' => $enTerm->term_id, 'element_type' => 'tax_mfn-news-tag')
+            array('element_id' => $enTerm->term_id, 'element_type' => 'tax_' . MFN_TAXONOMY_NAME)
         );
 
         $q = $wpdb->prepare("
@@ -391,7 +391,7 @@ function sync_mfn_taxonomy()
                 $wpdb->update(
                     $tbmlTranslations,
                     array('source_language_code' => 'en', 'language_code' => $lang, 'trid' => $trid),
-                    array('element_id' => $tbmlTerms, 'element_type' => 'tax_mfn-news-tag')
+                    array('element_id' => $tbmlTerms, 'element_type' => 'tax_' . MFN_TAXONOMY_NAME)
                 );
             }
 
@@ -405,7 +405,7 @@ function sync_mfn_taxonomy()
                 $wpdb->update(
                     $tbmlTranslations,
                     array('source_language_code' => 'en', 'language_code' => $lang, 'trid' => $trid),
-                    array('element_id' => $l_term->term_id, 'element_type' => 'tax_mfn-news-tag')
+                    array('element_id' => $l_term->term_id, 'element_type' => 'tax_' . MFN_TAXONOMY_NAME)
                 );
             }
         }

--- a/lib.php
+++ b/lib.php
@@ -18,20 +18,22 @@ function createTags($item)
 
     $newtag = array();
 
+    $slug_prefix = (MFN_TAG_PREFIX !== '' && MFN_TAG_PREFIX !== null ? MFN_TAG_PREFIX . '-' : '');
+
     array_push($newtag, MFN_TAG_PREFIX);
-    array_push($newtag, MFN_TAG_PREFIX . '-lang-' . $lang);
-    array_push($newtag, MFN_TAG_PREFIX . '-type-' . $type);
+    array_push($newtag, $slug_prefix . 'lang-' . $lang);
+    array_push($newtag, $slug_prefix . 'type-' . $type);
 
     foreach ($tags as $i => $tag) {
         if (startsWith($tag, ':correction')) {
-            array_push($newtag, MFN_TAG_PREFIX . '-correction');
+            array_push($newtag, $slug_prefix . '-correction');
             continue;
         }
 
         $tag = str_replace('sub:', '', $tag);
         $tag = trim($tag, ' :');
         $tag = str_replace(':', '-', $tag);
-        $tag = MFN_TAG_PREFIX . '-' . $tag;
+        $tag = $slug_prefix . $tag;
         array_push($newtag, $tag);
     }
 

--- a/mfn-wp-plugin.php
+++ b/mfn-wp-plugin.php
@@ -16,7 +16,7 @@
  * Plugin Name:       MFN Company Feed
  * Plugin URI:        https://github.com/modfin/mfn-wp-plugin
  * Description:       The MFN Company Feed plugin enables syncing of a news items feed for a particular company from mfn.se into Wordpress.
- * Version:           0.0.37
+ * Version:           0.0.38
  * Author:            Rasmus Holm
  * Author URI:        https://github.com/crholm
  * License:           GPL-2.0+

--- a/widgets.php
+++ b/widgets.php
@@ -1010,7 +1010,7 @@ class mfn_news_feed_widget extends WP_Widget
         $this->list_news_items($res, $tzLocation, $timestampFormat, $onlytagsallowed, $tagtemplate, $template, $groupbyyear, $showpreview, $previewlen);
 
         if ($showpagination) {
-            echo "</div></div><div class='mfn-newsfeed-pagination'>";
+            echo "</div><div class='mfn-newsfeed-pagination'>";
 
             if ($page > 0) {
                 $params = http_build_query(array_merge($_GET, array('m-page' => $page - 1)));
@@ -1026,7 +1026,6 @@ class mfn_news_feed_widget extends WP_Widget
                 echo "<a href='$url2' class='mfn-next-link'>$word</a>";
             }
 
-            echo "</div>";
         }
         echo "</div></div>";
         echo $args['after_widget'];


### PR DESCRIPTION
- Fixed so taxonomy name and tag prefix is change:able and applicable throughout the plugin
- Also fixed issue with </div> closures when using pagination in the news feed widget