### PR TITLE
MFN News feed widget hotfix

### DIFF
--- a/widgets/mfn_news_feed/class-mfn-news-feed.php
+++ b/widgets/mfn_news_feed/class-mfn-news-feed.php
@@ -114,6 +114,7 @@ class News_feed {
                 'title' => $item->post_title,
                 'url' => $item_url,
                 'tags' => $tags,
+                'year' => $year
             );
 
             $templateData['preview'] = '';


### PR DESCRIPTION
- Added support for '{{year}}' in HTML of the the template shortcode parameter