### PR TITLE
MFN WP Plugin changes and fixes

### DIFF
--- a/admin/partials/mfn-wp-plugin-admin-display.php
+++ b/admin/partials/mfn-wp-plugin-admin-display.php
@@ -69,30 +69,8 @@
         $is_subscribed = strlen($subscription_id) == 36;
         $is_disabled = $is_subscribed == true ? 'disabled' : '';
 
-        $wpml_enabled = ($use_wpml === "on" && $has_wpml);
-        $polylang_enabled = ($use_pll === "on" && $has_pll);
-
-        $default_lang = '';
-        $all_languages = [];
-
         // Get rewrite options
         $rewrite_post_type = isset($options['rewrite_post_type']) ? unserialize($options['rewrite_post_type']) : null;
-
-        if($wpml_enabled) {
-            if (function_exists('icl_get_default_language')) {
-                $default_lang = icl_get_default_language();
-                if (function_exists('icl_get_languages')) {
-                    $all_languages = icl_get_languages('skip_missing=1');
-                }
-            }
-        } else if($polylang_enabled) {
-            if (function_exists('pll_default_language')) {
-                $default_lang = pll_default_language();
-                if (function_exists('pll_languages_list')) {
-                    $all_languages = pll_languages_list();
-                }
-            }
-        }
 
         $default_tab = null;
         $tab = isset($_GET['tab']) ? $_GET['tab'] : $default_tab;
@@ -192,36 +170,12 @@
             </tbody>
         </table>
         <?php
-        if ($wpml_enabled || $polylang_enabled && sizeof($all_languages) > 0) {
-            echo '
-                <nav class="nav-tab-wrapper mfn-nav-tab-wrapper">
-                    <div class="mfn-tooltip-box">
-                        <span class="mfn-info-icon-wrapper"><i class="dashicons dashicons-info-outline"></i></span>
-                        <span class="mfn-tooltip-text">Listing all languages detected.</span>
-                    </div>
-            ';
-
-            foreach ($all_languages as $lang) {
-                $lang = $wpml_enabled ? $lang["language_code"] : $lang;
-                $is_default_lang = $default_lang === $lang ? " <small>(" . "Primary" . ")</small>" : '';
+                $slug = isset($rewrite_post_type['slug']) && $rewrite_post_type['slug'] !== '' ? $rewrite_post_type['slug'] : MFN_POST_TYPE;
+                $archive_name = isset($rewrite_post_type['archive-name']) && $rewrite_post_type['archive-name'] !== '' ? $rewrite_post_type['archive-name'] : MFN_ARCHIVE_NAME;
+                $singular_name = isset($rewrite_post_type['singular-name']) && $rewrite_post_type['singular-name'] !== '' ? $rewrite_post_type['singular-name'] : MFN_SINGULAR_NAME;
 
                 echo '
-                    <a data-lang=' . $lang . ' class="nav-tab mfn-nav-tab">' . $lang . $is_default_lang . '</a>
-                ';
-            }
-
-            echo "</nav>";
-            echo '<div class="mfn-tab-content">';
-
-            foreach ($all_languages as $lang) {
-                $lang = $wpml_enabled ? $lang["language_code"] : $lang;
-
-                $slug = isset($rewrite_post_type['slug_' . $lang]) && $rewrite_post_type['slug_' . $lang] !== '' ? $rewrite_post_type['slug_' . $lang] : MFN_POST_TYPE . '_' . $lang;
-                $archive_name = isset($rewrite_post_type['archive-name_' . $lang]) && $rewrite_post_type['archive-name_' . $lang] !== '' ? $rewrite_post_type['archive-name_' . $lang] : MFN_ARCHIVE_NAME;
-                $singular_name = isset($rewrite_post_type['singular-name_' . $lang]) && $rewrite_post_type['singular-name_' . $lang] !== '' ? $rewrite_post_type['singular-name_' . $lang] : MFN_SINGULAR_NAME;
-
-                echo '
-                <table class="mfn-hide mfn-lang-table mfn-lang-table-' . $lang . '">
+                <table class="mfn-hide mfn-lang-table">
                     <tbody>
                         <tr>
                             <td>
@@ -239,7 +193,7 @@
                         </tr>
                         <tr>
                             <td class="mfn-lang-td">
-                                <input type="text" class="regular-text" name="' . $this->plugin_name . '[rewrite_post_type][slug_' . $lang . ']' . '" value="' . $slug . '" ' . $is_disabled . '>
+                                <input type="text" class="regular-text" name="' . $this->plugin_name . '[rewrite_post_type][slug]' . '" value="' . $slug . '" ' . $is_disabled . '>
                                 <div class="mfn-tooltip-box">
                                     <span class="mfn-info-icon-wrapper"><i class="dashicons dashicons-info-outline"></i></span>
                                     <span class="mfn-tooltip-text">Rewrite the slug (' . MFN_POST_TYPE . ') in the URL - eg. "press-releases"</span>
@@ -262,7 +216,7 @@
                         </tr>
                         <tr>
                             <td class="mfn-lang-td">
-                                <input type="text" class="regular-text" name="' . $this->plugin_name . '[rewrite_post_type][archive-name_' . $lang . ']' . '" value="' . $archive_name . '" ' . $is_disabled . '>
+                                <input type="text" class="regular-text" name="' . $this->plugin_name . '[rewrite_post_type][archive-name]' . '" value="' . $archive_name . '" ' . $is_disabled . '>
                                 <div class="mfn-tooltip-box">
                                     <span class="mfn-info-icon-wrapper"><i class="dashicons dashicons-info-outline"></i></span>
                                     <span class="mfn-tooltip-text">Set a custom name of the news archive page  - eg. "Press Releases"</span>
@@ -285,14 +239,14 @@
                         </tr>
                         <tr>
                             <td class="mfn-lang-td">
-                                <input type="text" class="regular-text" name="' . $this->plugin_name . '[rewrite_post_type][singular-name_' . $lang . ']' . '" value="' . $singular_name . '" ' . $is_disabled . '>
+                                <input type="text" class="regular-text" name="' . $this->plugin_name . '[rewrite_post_type][singular-name]' . '" value="' . $singular_name . '" ' . $is_disabled . '>
                                 <div class="mfn-tooltip-box">
                                     <span class="mfn-info-icon-wrapper"><i class="dashicons dashicons-info-outline"></i></span>
                                     <span class="mfn-tooltip-text">Set a custom name of a single news item - eg. "Press release"</span>
                                 </div>
                             </td>
                          </tr>';
-                        if(!isset($rewrite_post_type['slug_' . $lang])) {
+                        if(!isset($rewrite_post_type['slug'])) {
                             echo '
                             <tr>
                                 <td class="mfn-info-td">
@@ -303,100 +257,7 @@
                         echo '
                     </tbody>
                 </table>
-                ';
-            }
-                echo "</div>";
-        } else {
-                $single_slug = isset($rewrite_post_type['single-slug']) && $rewrite_post_type['single-slug'] !== '' ? $rewrite_post_type['single-slug'] : MFN_POST_TYPE;
-                $archive_name = isset($rewrite_post_type['archive-name']) && $rewrite_post_type['archive-name'] !== '' ? $rewrite_post_type['archive-name'] : MFN_ARCHIVE_NAME;
-                $singular_name = isset($rewrite_post_type['singular-name']) && $rewrite_post_type['singular-name'] !== '' ? $rewrite_post_type['singular-name'] : MFN_SINGULAR_NAME;
-
-                echo '
-                <table class="mfn-hide mfn-lang-table">
-                    <tbody>
-                        <tr>
-                            <td>
-                ';
-                ?>
-                                <label>
-                                    <?php echo _e('Custom Post Type URL Slug', $this->plugin_name) . ' <small>(Default: ' . MFN_POST_TYPE . ')</small>'; ?>
-                                </label>
-                                <legend class="screen-reader-text">
-                                    <?php _e('Custom Post Type URL Slug', $this->plugin_name); ?>
-                                </legend>
-                <?php
-                echo '
-                            </td>
-                        </tr>
-                        <tr>
-                            <td class="mfn-lang-td">     
-                                <input type="text" class="regular-text" name="' . $this->plugin_name . '[rewrite_post_type][single-slug]' . '" value="' . $single_slug . '" ' . $is_disabled . '>
-                                <div class="mfn-tooltip-box">
-                                    <span class="mfn-info-icon-wrapper"><i class="dashicons dashicons-info-outline"></i></span>
-                                    <span class="mfn-tooltip-text">Rewrite the slug (' . MFN_POST_TYPE . ') in the URL - eg. "press-releases"</span>
-                                </div>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td>
-                ';
-                ?>
-                                <label>
-                                    <?php echo _e('Custom Archive Name', $this->plugin_name) . ' <small>(Default: MFN News Items)</small>'; ?>
-                                </label>
-                                <legend class="screen-reader-text">
-                                    <?php _e('Custom Archive Name', $this->plugin_name); ?>
-                                </legend>
-                <?php
-                echo '
-                            </td>
-                        </tr>
-                        <tr>
-                            <td class="mfn-lang-td">     
-                                <input type="text" class="regular-text" name="' . $this->plugin_name . '[rewrite_post_type][archive-name]' . '" value="' . $archive_name . '" ' . $is_disabled . '>
-                                <div class="mfn-tooltip-box">
-                                    <span class="mfn-info-icon-wrapper"><i class="dashicons dashicons-info-outline"></i></span>
-                                    <span class="mfn-tooltip-text">Set a custom name of the news archive page  - eg. "Press Releases"</span>
-                                </div>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td>
-                ';
-            ?>
-                                <label>
-                                    <?php echo _e('Custom Singular Name', $this->plugin_name) . ' <small>(Default: MFN News Item)</small>'; ?>
-                                </label>
-                                <legend class="screen-reader-text">
-                                    <?php _e('Custom Singular Name', $this->plugin_name); ?>
-                                </legend>
-            <?php
-            echo '
-                            </td>
-                        </tr>
-                        <tr>
-                            <td class="mfn-lang-td">     
-                                <input type="text" class="regular-text" name="' . $this->plugin_name . '[rewrite_post_type][singular-name]' . '" value="' . $singular_name . '" ' . $is_disabled . '>
-                                <div class="mfn-tooltip-box">
-                                    <span class="mfn-info-icon-wrapper"><i class="dashicons dashicons-info-outline"></i></span>
-                                    <span class="mfn-tooltip-text">Set a custom name of a single news item - eg. "Press release"</span>
-                                </div>
-                            </td>
-                        </tr>';
-            if(!isset($rewrite_post_type['single-slug'])) {
-                echo '
-                         <tr>
-                            <td class="mfn-info-td">
-                                <span class="mfn-info-box do-fade"><i class="dashicons dashicons-warning"></i> <span class="mfn-info-box-text">Unsaved!</span></span>
-                            </td>
-                         </tr>
-                ';
-                }
-                echo '
-                    </tbody>
-                </table>
-                ';
-            }
+            ';
         ?>
         <table>
             <tbody>
@@ -407,7 +268,7 @@
                             <label for="<?php echo $this->plugin_name; ?>-disable_archive"><?php _e('Disable Archive', $this->plugin_name); ?></label>
                             <legend class="screen-reader-text"><?php _e('Disable Archive', $this->plugin_name); ?></legend>
                             <br>
-                            <small>(<?php _e('Makes the news archive unreachable - eg. ' .  get_home_url() . '/' . get_post_type_object('mfn_news')->rewrite['slug']); ?>)</small>
+                            <small>(<?php _e('Makes the news archive unreachable - eg. ' .  rtrim(get_home_url(), '/') . '/' . get_post_type_object('mfn_news')->rewrite['slug'] . '. You might need to update <a href="' . get_home_url() . '/wp-admin/options-permalink.php">permalinks</a> after saving to activate this setting.'); ?>)</small>
                         </p>
                     <td>
                 </tr>

--- a/config.php
+++ b/config.php
@@ -85,9 +85,8 @@ function register_mfn_types()
 {
     if (empty(MFN_POST_TYPE)) {
         die("MFN News Feed - The post type was empty. Please enter a post type name in consts.php.");
-    }
-    else {
-        $supports = array( 'title', 'editor');
+    } else {
+        $supports = array('title', 'editor');
         if (isset(get_option(MFN_PLUGIN_NAME)['thumbnail_on'])) {
             $supports = array('title', 'editor', 'thumbnail');
         }
@@ -106,7 +105,7 @@ function register_mfn_types()
     }
 
     // do url rewrite option upon settings save
-    add_action('update_option_mfn-wp-plugin', function() {
+    add_action('update_option_mfn-wp-plugin', function () {
         register_mfn_types();
         flush_rewrite_rules(false);
     }, 11, 3);
@@ -275,7 +274,7 @@ function sync_mfn_taxonomy()
                             [
                                 "slug" => "issuance",
                                 "name" => "Issuance",
-                                "i10n" => ["sv" => "Emission", 'fi'=>"Osakeanti"]
+                                "i10n" => ["sv" => "Emission", 'fi' => "Osakeanti"]
                             ],
                             [
                                 "slug" => "repurchase",
@@ -305,7 +304,7 @@ function sync_mfn_taxonomy()
                             [
                                 "slug" => "notice",
                                 "name" => "Notice",
-                                "i10n" => ["sv" => "Kallelse", 'fi'=>"Kutsumus"]
+                                "i10n" => ["sv" => "Kallelse", 'fi' => "Kutsumus"]
                             ],
                             [
                                 "slug" => "info",
@@ -465,13 +464,13 @@ function sync_mfn_taxonomy()
         $translations = array();
         $translations['en'] = $enTerm->term_id;
 
-        $allowed = pll_the_languages( array( 'raw' => true));
+        $allowed = pll_the_languages(array('raw' => true));
 
         foreach ($enItem['i10n'] as $i10nLang => $name) {
 
             $lang = $pllLangMapping[$i10nLang];
 
-            if(!array_key_exists($lang, $allowed)){
+            if (!array_key_exists($lang, $allowed)) {
                 continue;
             }
             $slug = $enTerm->slug . "_" . $lang;
@@ -479,17 +478,17 @@ function sync_mfn_taxonomy()
             $l_parent_term_id = 0;
             if ($enParentTerm != null) {
                 $p_slug = $enParentTerm->slug . '_' . $lang;
-                $pterms = get_terms( array(
+                $pterms = get_terms(array(
                     'taxonomy' => MFN_TAXONOMY_NAME,
                     'hide_empty' => false,
                     'slug' => $p_slug
-                ) );
-                if (sizeof($pterms) == 0){
-                    $pterms = get_terms( array(
+                ));
+                if (sizeof($pterms) == 0) {
+                    $pterms = get_terms(array(
                         'taxonomy' => MFN_TAXONOMY_NAME,
                         'hide_empty' => false,
-                         'slug' => $p_slug,
-                     'lang' => $lang
+                        'slug' => $p_slug,
+                        'lang' => $lang
                     ));
                 }
 
@@ -498,20 +497,20 @@ function sync_mfn_taxonomy()
                 }
             }
 
-            $terms = get_terms( array(
+            $terms = get_terms(array(
                 'taxonomy' => MFN_TAXONOMY_NAME,
                 'hide_empty' => false,
                 'slug' => $slug
             ));
-            if (sizeof($terms) == 0){
+            if (sizeof($terms) == 0) {
                 $ids = wp_insert_term($name, MFN_TAXONOMY_NAME, array(
                     'slug' => $slug,
                     'parent' => $l_parent_term_id,
                 ));
-                if (is_array($ids)){
+                if (is_array($ids)) {
                     pll_set_term_language($ids['term_id'], $lang);
                 }
-                $terms = get_terms( array(
+                $terms = get_terms(array(
                     'taxonomy' => MFN_TAXONOMY_NAME,
                     'hide_empty' => false,
                     'slug' => $slug,
@@ -534,22 +533,22 @@ function sync_mfn_taxonomy()
         pll_save_term_translations($translations);
     };
 
-    $getTerm = function($slug, $lang){
-        $terms = get_terms( array(
+    $getTerm = function ($slug, $lang) {
+        $terms = get_terms(array(
             'taxonomy' => MFN_TAXONOMY_NAME,
             'hide_empty' => false,
             'slug' => $slug,
         ));
-        if (sizeof($terms) == 0){
-            $terms = get_terms( array(
+        if (sizeof($terms) == 0) {
+            $terms = get_terms(array(
                 'taxonomy' => MFN_TAXONOMY_NAME,
                 'hide_empty' => false,
                 'slug' => $slug,
                 'lang' => $lang
             ));
         }
-        if (sizeof($terms) == 0){
-            $terms = get_terms( array(
+        if (sizeof($terms) == 0) {
+            $terms = get_terms(array(
                 'taxonomy' => MFN_TAXONOMY_NAME,
                 'hide_empty' => false,
                 'slug' => $slug,
@@ -568,7 +567,7 @@ function sync_mfn_taxonomy()
 
         $term = $getTerm($slug, 'en');
 
-        if ($term == false){
+        if ($term == false) {
             wp_insert_term($item['name'], MFN_TAXONOMY_NAME, array(
                 'slug' => $slug,
                 'parent' => $parent_id,

--- a/config.php
+++ b/config.php
@@ -3,36 +3,6 @@
 require_once('consts.php');
 require_once('api.php');
 
-function is_language_plugin_enabled(): bool
-{
-    $uses_wpml = isset(get_option(MFN_PLUGIN_NAME)['use_wpml']) && get_option(MFN_PLUGIN_NAME)['use_wpml'] === 'on';
-    $uses_pll = isset(get_option(MFN_PLUGIN_NAME)['use_pll']) && get_option(MFN_PLUGIN_NAME)['use_pll'] === 'on';
-    return $uses_wpml || $uses_pll;
-}
-
-function get_current_language(): string
-{
-    $current_lang = '';
-    $wpml_active_enabled = defined('WPML_PLUGIN_BASENAME') && isset(get_option(MFN_PLUGIN_NAME)['use_wpml']) && get_option(MFN_PLUGIN_NAME)['use_wpml'] === 'on';
-    $pll_active_enabled = defined('POLYLANG_BASENAME') && isset(get_option(MFN_PLUGIN_NAME)['use_pll']) && get_option(MFN_PLUGIN_NAME)['use_pll'] === 'on';
-
-    if (function_exists('icl_get_current_language') && $wpml_active_enabled) {
-            $current_lang = icl_get_current_language();
-    } else if (function_exists('pll_current_language') && $pll_active_enabled) {
-            $current_lang = pll_current_language();
-    }
-    // if no current language fallback to default
-    if (!$current_lang) {
-        if (function_exists('icl_get_default_language')) {
-            $current_lang = icl_get_default_language();
-        }
-        else if (function_exists('pll_default_language')) {
-            $current_lang = pll_default_language();
-        }
-    }
-    return $current_lang;
-}
-
 // If ABSPATH not defined, php app is initiated from plugin folder.
 // Lets try to find and run wp-config.php
 if (!defined('ABSPATH')) {
@@ -75,7 +45,8 @@ if (isset(get_option(MFN_PLUGIN_NAME)['rewrite_post_type'])) {
     // adding filter for rewriting the post_type from settings
     add_filter('register_post_type_args', 'rewrite_post_type', 10, 2);
 
-    function rewrite_post_type($args, $post_type) {
+    function rewrite_post_type($args, $post_type)
+    {
         if ($post_type === 'mfn_news') {
             $rewrite_post_type = unserialize(get_option(MFN_PLUGIN_NAME)['rewrite_post_type']);
             $disable_archive = isset(get_option(MFN_PLUGIN_NAME)['disable_archive']) && get_option(MFN_PLUGIN_NAME)['disable_archive'] === 'on';
@@ -84,22 +55,8 @@ if (isset(get_option(MFN_PLUGIN_NAME)['rewrite_post_type'])) {
             $rewrite_archive_name = '';
             $rewrite_singular_name = '';
 
-            $current_lang = get_current_language();
-
-            // has language plugin
-            if (isset($rewrite_post_type['slug_' . $current_lang])) {
-                $rewrite_slug = $rewrite_post_type['slug_' . $current_lang];
-            }
-            if (isset($rewrite_post_type['archive-name_' . $current_lang])) {
-                $rewrite_archive_name = $rewrite_post_type['archive-name_' . $current_lang];
-            }
-            if (isset($rewrite_post_type['singular-name_' . $current_lang])) {
-                $rewrite_singular_name = $rewrite_post_type['singular-name_' . $current_lang];
-            }
-
-            // no language plugin
-            if (isset($rewrite_post_type['single-slug'])) {
-                $rewrite_slug = $rewrite_post_type['single-slug'];
+            if (isset($rewrite_post_type['slug'])) {
+                $rewrite_slug = $rewrite_post_type['slug'];
             }
             if (isset($rewrite_post_type['archive-name'])) {
                 $rewrite_archive_name = $rewrite_post_type['archive-name'];
@@ -109,19 +66,16 @@ if (isset(get_option(MFN_PLUGIN_NAME)['rewrite_post_type'])) {
             }
 
             // rewrite
-            if (isset($args['rewrite'])) {
-                if ($rewrite_slug !== '' && $rewrite_slug !== MFN_POST_TYPE) {
-                    $args['rewrite']['slug'] = $rewrite_slug;
-                }
-                if ($rewrite_archive_name !== '' && $rewrite_archive_name !== MFN_ARCHIVE_NAME) {
-                    $args['labels']['name'] = $rewrite_archive_name;
-                }
-                if ($rewrite_singular_name !== '' && $rewrite_singular_name !== MFN_SINGULAR_NAME) {
-                    $args['labels']['singular_name'] = $rewrite_singular_name;
-                }
-
-                $args['has_archive'] = !$disable_archive;
+            if ($rewrite_slug !== '' && $rewrite_slug !== MFN_POST_TYPE) {
+                $args['rewrite']['slug'] = $rewrite_slug;
             }
+            if ($rewrite_archive_name !== '' && $rewrite_archive_name !== MFN_ARCHIVE_NAME) {
+                $args['labels']['name'] = $rewrite_archive_name;
+            }
+            if ($rewrite_singular_name !== '' && $rewrite_singular_name !== MFN_SINGULAR_NAME) {
+                $args['labels']['singular_name'] = $rewrite_singular_name;
+            }
+            $args['has_archive'] = !$disable_archive;
         }
         return $args;
     }
@@ -135,7 +89,7 @@ function register_mfn_types()
     else {
         $supports = array( 'title', 'editor');
         if (isset(get_option(MFN_PLUGIN_NAME)['thumbnail_on'])) {
-            $supports = array( 'title', 'editor', 'thumbnail');
+            $supports = array('title', 'editor', 'thumbnail');
         }
 
         register_post_type(MFN_POST_TYPE,

--- a/widgets.php
+++ b/widgets.php
@@ -1228,9 +1228,11 @@ class mfn_news_feed_widget extends WP_Widget
 
             if ($showfilter || $showyears) {
                 echo '</div>';
-                echo '  <input type="hidden" id="instance_id" value="' . $instance_id . '" />';
-                echo '</form>';
             }
+        }
+        if ($showfilter || $showyears) {
+            echo '  <input type="hidden" id="instance_id" value="' . $instance_id . '" />';
+            echo '</form>';
         }
 
         echo '<div class="mfn-list">';


### PR DESCRIPTION
- Changing rewrite settings: It's now no longer possible to rewrite the slug (mfn_news) per different languages. This change was needed to ensure compatibility with language plugins, for example WPML. 
- Fixed issue for filter where filtertype=buttons click event only worked if showfilter was true
- Minor refactoring