### PR TITLE
Polylang fixes, and additional stuff

### DIFF
--- a/admin/css/mfn-wp-plugin-admin.css
+++ b/admin/css/mfn-wp-plugin-admin.css
@@ -132,6 +132,10 @@ input.wide {
     color: rgba(44,51,56,.5);
 }
 
+.mfn-settings-table input::placeholder {
+    color: rgba(44,51,56,.5);
+}
+
 .mfn-settings-table th {
     text-align: left;
 }

--- a/admin/js/mfn-wp-plugin-admin.js
+++ b/admin/js/mfn-wp-plugin-admin.js
@@ -47,8 +47,12 @@
         return new Promise((resolve) => setTimeout(resolve, ms));
     }
 
+    function no_cache_param(p) {
+        return p + 'no-cache='+Math.round((Math.random()*1000000));
+    }
+
     function mfn_sync_single_item(post_id) {
-        $.get(mfn_admin_params.plugin_url + '/cc.php?mode=sync&limit=1&offset=0&post_id=' + post_id)
+        $.get(mfn_admin_params.plugin_url + '/cc.php?mode=sync&limit=1&offset=0&post_id=' + post_id + no_cache_param('&'))
             .done(function () {
             if (post_id !== null) {
                 $('#mfn-item-restore-status').html('');
@@ -83,7 +87,7 @@
                 .html('<div class=\'mfn-do-fade mfn-spinner-container\'><span class=\'mfn-spinner\'></span></div> Waiting...</span>');
         }
 
-        $.get(mfn_admin_params.plugin_url + '/cc.php?mode=sync&limit=' + limit + '&offset=' + offset, function (data) {
+        $.get(mfn_admin_params.plugin_url + '/cc.php?mode=sync&limit=' + limit + '&offset=' + offset + no_cache_param('&'), function (data) {
             sync_condition = 'running';
             var fetched = parseInt(data.split(' ')[0]);
             var inserted = parseInt(data.split(' ')[1]);
@@ -127,7 +131,7 @@
 
     async function syncTax() {
         $('#mfn-sync-tax-status').html('<div class=\'mfn-do-fade mfn-spinner-container\'><span class=\'mfn-spinner\'></span></div>');
-        await $.get(mfn_admin_params.plugin_url + '/cc.php?mode=sync-tax', function () {
+        await $.get(mfn_admin_params.plugin_url + '/cc.php?mode=sync-tax' + no_cache_param('&'), function () {
             $('#mfn-sync-tax-status')
                 .html("<div class='mfn-status-container mfn-highlight-status mfn-do-slide-top'><span class=\"dashicons dashicons-yes mfn-success-icon mfn-do-fade\"></span>Done!</div>");
         });
@@ -246,7 +250,7 @@
             return;
         }
 
-        $.get(pluginUrl + '/cc.php?mode=ping', function (data) {
+        $.get(pluginUrl + '/cc.php?mode=ping' + no_cache_param('&'), function (data) {
             if (data === 'pong') {
                 pluginUrlTestEl
                     .html("<span class=\"dashicons dashicons-yes mfn-success-icon mfn-do-fade\"></span><span style='cursor:default;' title='" + mfn_admin_params.plugin_url  + "'><strong>Current:</strong> (" + mfn_admin_params.plugin_url + ")</span>");
@@ -301,7 +305,7 @@
         var subStatusEl = $('#mfn-subscription-status');
         var subStatusContainerEl = $('#mfn-status-container');
 
-        $.get(pluginUrl + '/cc.php?mode=verify-subscription').done(function (res) {
+        $.get(pluginUrl + '/cc.php?mode=verify-subscription' + no_cache_param('&')).done(function (res) {
             // got error from websub verification
             if (msg !== '') {
                 mfn_subscription_error(msg, 'mfn-subscription-status');
@@ -341,7 +345,7 @@
         var subStatusEl = $('#mfn-subscription-status');
         $('#mfn-sub-button').attr("disabled", true);
 
-        $.get(pluginUrl + '/cc.php?mode=subscribe', function (msg) {
+        $.get(pluginUrl + '/cc.php?mode=subscribe' + no_cache_param('&'), function (msg) {
             subStatusEl.html('<div class=\'mfn-do-fade mfn-spinner-container\'><span class=\'mfn-spinner\'></span></div> Subscribing...');
             mfn_verify_subscription(pluginUrl, verificationRetries, msg);
         });
@@ -353,7 +357,7 @@
         $('#mfn-unsub-button').attr("disabled", true);
         $('#save-submit-btn').prop("disabled", false);
 
-        $.get(pluginUrl + '/cc.php?mode=unsubscribe', function () {
+        $.get(pluginUrl + '/cc.php?mode=unsubscribe' + no_cache_param('&'), function () {
             subStatusEl
                 .html('<div class=\'mfn-do-fade mfn-spinner-container\'><span class=\'mfn-spinner\'></span></div> Unsubscribing...');
 
@@ -377,7 +381,7 @@
     function mfn_clear_settings(){
         var pluginUrl = mfn_admin_params.plugin_url;
 
-        $.get(pluginUrl + '/cc.php?mode=clear-settings', function () {
+        $.get(pluginUrl + '/cc.php?mode=clear-settings' + no_cache_param('&'), function () {
             setTimeout(function () {
                 location.reload();
             }, 100);
@@ -399,7 +403,7 @@
             .html('<span class="mfn-status-container mfn-status-container-delete mfn-do-fade"><div class=\'mfn-do-fade mfn-spinner-container\'><span class=\'mfn-spinner\'></span></div> <b>Deleting tags...</b></span>');
         delTagsBtnSpanEl.removeClass("dashicons dashicons-tag");
         delTagsBtnSpanEl.html('<div class=\'mfn-do-fade\'><span class=\'mfn-spinner\'></span></div>');
-        $.get(pluginUrl + '/cc.php?mode=delete-all-tags&limit=10', function (data) {
+        $.get(pluginUrl + '/cc.php?mode=delete-all-tags&limit=10' + no_cache_param('&'), function (data) {
             var parts = data.split(';');
             var i = parseInt(parts[0]);
             var deleted = parseInt(parts[1]);
@@ -422,7 +426,7 @@
         if (acceptedTypes.includes(type)) {
 
             var modalUrl = mfn_admin_params.plugin_url + '/admin/partials/modals/mfn-modal-' + type + '.php';
-            await $.get(modalUrl, function (data) {
+            await $.get(modalUrl + no_cache_param('?'), function (data) {
                 $('body').append(data);
                 // modal main events
                 $('.mfn-close-modal').click(function() {
@@ -449,7 +453,7 @@
             delPostsBtnSpanEl.addClass("dashicons dashicons-admin-post");
         }
 
-        $.get(pluginUrl + '/cc.php?mode=delete-all-posts&limit=10&include-dirty=' + includeDirty, function (data, xhr) {
+        $.get(pluginUrl + '/cc.php?mode=delete-all-posts&limit=10&include-dirty=' + includeDirty + no_cache_param('&'), function (data, xhr) {
             var parts = data.split(';');
             var i = parseInt(parts[0]);
             var deleted = parseInt(parts[1]);

--- a/admin/partials/mfn-wp-plugin-admin-display.php
+++ b/admin/partials/mfn-wp-plugin-admin-display.php
@@ -70,12 +70,14 @@ $thumbnail_allow_delete = $options['thumbnail_allow_delete'] ?? 'off';
 $verify_signature = $options['verify_signature'] ?? 'off';
 $reset_cache = $options['reset_cache'] ?? 'on';
 $enable_attachments = $options['enable_attachments'] ?? 'off';
+$taxonomy_disable_cus_prefix = $options['taxonomy_disable_cus_prefix'] ?? "off";
 
 // Rewrite settings
 $rewrite = isset($options['rewrite_post_type']) ? unserialize($options['rewrite_post_type']) : null;
 $slug = (isset($rewrite['slug']) && $rewrite['slug'] !== '' ? $rewrite['slug'] : MFN_POST_TYPE);
 $archive_name = (isset($rewrite['archive-name']) && $rewrite['archive-name'] !== '' ? $rewrite['archive-name'] : MFN_ARCHIVE_NAME);
 $singular_name = (isset($rewrite['singular-name']) && $rewrite['singular-name'] !== '' ? $rewrite['singular-name'] : MFN_SINGULAR_NAME);
+$taxonomy_rewrite_slug = $options['taxonomy_rewrite_slug'] ?? '';
 
 // HTML
 echo '
@@ -181,6 +183,21 @@ echo '
                             <div class="mfn-tooltip-box">
                                 <span class="mfn-info-icon-wrapper"><i class="dashicons dashicons-info-outline"></i></span>
                                 <span class="mfn-tooltip-text">' . mfn_get_text('tooltip_rewrite_post_type_slug') . '</span>
+                            </div>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                        ' . mfn_parse_label('label_rewrite_taxonomy_slug') . '
+                        ' . mfn_parse_small('small_mfn-news-tag') . '
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="mfn-inline-td">
+                            <input type="text" class="regular-text wide" pattern="\S+" name="' . $this->plugin_name . '[taxonomy_rewrite_slug]' . '" id="' . $this->plugin_name . '-taxonomy_rewrite_slug"' . ' value="' . $taxonomy_rewrite_slug . '" ' . $is_readonly . ' placeholder="' . MFN_TAXONOMY_NAME . '">
+                            <div class="mfn-tooltip-box">
+                                <span class="mfn-info-icon-wrapper"><i class="dashicons dashicons-info-outline"></i></span>
+                                <span class="mfn-tooltip-text">' . mfn_get_text('tooltip_taxonomy_rewrite_slug') . '</span>
                             </div>
                         </td>
                     </tr>
@@ -380,6 +397,16 @@ echo '
                             ' . mfn_parse_label('label_enable_attachments') . '
                             <br>
                             ' . mfn_parse_small('small_enable_attachments_description') . '
+                        </p>
+                    <td>
+                </tr>
+                <tr>
+                    <td>
+                        <p>
+                            <input type="checkbox" id="' . $this->plugin_name . '-taxonomy_disable_cus_prefix" name="' . $this->plugin_name . '[taxonomy_disable_cus_prefix]" ' . checked($taxonomy_disable_cus_prefix, "on", false) . ' value="on" ' . $is_readonly . '>
+                            ' . mfn_parse_label('label_taxonomy_disable_cus_prefix') . '
+                            <br>
+                            ' . mfn_parse_small('small_taxonomy_disable_cus_prefix_description') . '
                         </p>
                     <td>
                 </tr>

--- a/admin/partials/modals/mfn-modal-clear-settings.php
+++ b/admin/partials/modals/mfn-modal-clear-settings.php
@@ -1,6 +1,13 @@
 <?php
 require_once('../../../config.php');
 
+$is_admin = current_user_can('manage_options');
+
+if (!$is_admin) {
+    echo "you are not admin";
+    die();
+}
+
 $queries = array();
 parse_str($_SERVER['QUERY_STRING'], $queries);
 

--- a/admin/partials/modals/mfn-modal-delete-posts.php
+++ b/admin/partials/modals/mfn-modal-delete-posts.php
@@ -1,6 +1,13 @@
 <?php
 require_once('../../../config.php');
 
+$is_admin = current_user_can('manage_options');
+
+if (!$is_admin) {
+    echo "you are not admin";
+    die();
+}
+
 $queries = array();
 parse_str($_SERVER['QUERY_STRING'], $queries);
 

--- a/admin/partials/modals/mfn-modal-delete-tags.php
+++ b/admin/partials/modals/mfn-modal-delete-tags.php
@@ -1,6 +1,13 @@
 <?php
 require_once('../../../config.php');
 
+$is_admin = current_user_can('manage_options');
+
+if (!$is_admin) {
+    echo "you are not admin";
+    die();
+}
+
 $queries = array();
 parse_str($_SERVER['QUERY_STRING'], $queries);
 

--- a/admin/partials/modals/mfn-modal-restore-item.php
+++ b/admin/partials/modals/mfn-modal-restore-item.php
@@ -1,6 +1,13 @@
 <?php
 require_once('../../../config.php');
 
+$is_admin = current_user_can('manage_options');
+
+if (!$is_admin) {
+    echo "you are not admin";
+    die();
+}
+
 $queries = array();
 parse_str($_SERVER['QUERY_STRING'], $queries);
 

--- a/admin/partials/sections/mfn-wp-plugin-admin-status.php
+++ b/admin/partials/sections/mfn-wp-plugin-admin-status.php
@@ -1,6 +1,13 @@
 <?php
 require_once('../../../config.php');
 
+$is_admin = current_user_can('manage_options');
+
+if (!$is_admin) {
+    echo "you are not admin";
+    die();
+}
+
 $subscriptions = get_option("mfn-subscriptions");
 $subscription = mfn_get_subscription_by_plugin_url($subscriptions, mfn_plugin_url());
 $subscription_id = $subscription['subscription_id'] ?? "";

--- a/api.php
+++ b/api.php
@@ -429,8 +429,12 @@ ON p.ID = lang.post_id
 INNER JOIN (
   SELECT 
   po.ID, 
-  group_concat(CONCAT(ter.name, ':', ter.slug) ORDER BY ter.slug LIKE '" . MFN_TAG_PREFIX . "-cus-%', ter.slug) AS tags, 
-  group_concat(SUBSTRING_INDEX(ter.slug, '_', 1) ORDER BY ter.slug LIKE '" . MFN_TAG_PREFIX . "-cus-%', ter.slug) AS tag_slugs
+  group_concat(CONCAT(ter.name, ':', ter.slug)
+    ORDER BY (ter.slug LIKE '" . MFN_TAG_PREFIX . "-cus-%'
+      || ter.slug NOT LIKE '" . MFN_TAG_PREFIX . "%'), ter.slug) AS tags,
+  group_concat(SUBSTRING_INDEX(ter.slug, '_', 1)
+    ORDER BY (ter.slug LIKE '" . MFN_TAG_PREFIX . "-cus-%'
+      || ter.slug NOT LIKE '" . MFN_TAG_PREFIX . "%'), ter.slug) AS tag_slugs
   FROM $wpdb->posts po
          INNER JOIN $wpdb->term_relationships r
                     ON r.object_id = po.ID

--- a/cc.php
+++ b/cc.php
@@ -182,9 +182,16 @@ function mfn_delete_all_tags(): array
 
 	$options      = get_option( "mfn-wp-plugin" );
 	$wpml_enabled = defined( 'WPML_PLUGIN_BASENAME' ) && isset( $options['language_plugin'] ) && $options['language_plugin'] == 'wpml';
+	$pll_enabled = isset($options['language_plugin']) && $options['language_plugin'] == 'pll';
 
 	if ( $wpml_enabled ) {
 		$terms = MFN_get_terms_wpml( '' );
+	} else if ( $pll_enabled ) {
+		$terms = get_terms( array(
+			'taxonomy'   => MFN_TAXONOMY_NAME,
+			'hide_empty' => false,
+			'lang' => '',
+		) );
 	} else {
 		$terms = get_terms( array(
 			'taxonomy'   => MFN_TAXONOMY_NAME,

--- a/config.php
+++ b/config.php
@@ -151,6 +151,11 @@ function mfn_register_types()
         'menu_name' => __('News Tags'),
     );
 
+    $taxonomy_rewrite_slug = '';
+    if (isset(get_option(MFN_PLUGIN_NAME)['taxonomy_rewrite_slug'])) {
+        $taxonomy_rewrite_slug = get_option(MFN_PLUGIN_NAME)['taxonomy_rewrite_slug'];
+    }
+
     register_taxonomy(MFN_TAXONOMY_NAME, array(MFN_POST_TYPE), array(
         'hierarchical' => true,
         'labels' => $labels,
@@ -158,7 +163,7 @@ function mfn_register_types()
         'show_admin_column' => true,
         'show_in_menu' => true,
         'query_var' => true,
-        'rewrite' => array('slug' => MFN_TAXONOMY_NAME),
+        'rewrite' => array('slug' => empty($taxonomy_rewrite_slug) ? MFN_TAXONOMY_NAME : $taxonomy_rewrite_slug),
     ));
 
 }
@@ -168,7 +173,7 @@ function mfn_sync_taxonomy()
     $tax = [
         "slug" => MFN_TAG_PREFIX,
         "name" => "News",
-        "i10n" => ["sv" => "Nyheter"],
+        "i10n" => ["sv" => "Nyheter", "fi" => "Uutiset"],
         "children" => [
             [
                 "slug" => "type-ir",
@@ -196,6 +201,16 @@ function mfn_sync_taxonomy()
                 "i10n" => ["sv" => "Finska", 'fi' => "Suomi"]
             ],
             [
+                "slug" => "lang-no",
+                "name" => "Norwegian",
+                "i10n" => ["sv" => "Norska"]
+            ],
+            [
+                "slug" => "lang-zh",
+                "name" => "Chinese",
+                "i10n" => ["sv" => "Kinesiska"]
+            ],
+            [
                 "slug" => "correction",
                 "name" => "Correction",
                 "i10n" => ["sv" => "Korrektion", 'fi' => "Korjaaminen"],
@@ -221,11 +236,20 @@ function mfn_sync_taxonomy()
                         "i10n" => ["sv" => "LHFI"]
                     ],
                     [
+                        "slug" => "nsta",
+                        "name" => "NSTA",
+                        "i10n" => ["sv" => "NSTA"]
+                    ],
+                    [
+                        "slug" => "dcma",
+                        "name" => "DCMA",
+                        "i10n" => ["sv" => "DCMA"]
+                    ],
+                    [
                         "slug" => "listing",
                         "name" => "Listing Regulation",
                         "i10n" => ["sv" => "Noteringskrav", 'fi' => "Listausvaatimukset"]
                     ],
-
                 ]
             ],
             [
@@ -263,7 +287,6 @@ function mfn_sync_taxonomy()
                                 "name" => "Yearend",
                                 "i10n" => ["sv" => "Bokslutskommuniké", 'fi' => "Vuoden loppu"]
                             ],
-
                         ]
                     ],
                 ]
@@ -294,6 +317,36 @@ function mfn_sync_taxonomy()
                         "i10n" => ["sv" => "Prospekt", 'fi' => "Esite"]
                     ],
                     [
+                        "slug" => "aoa",
+                        "name" => "Articles of association",
+                        "i10n" => ["sv" => "Bolagsordning", 'fi' => "Yhtiöjärjestys"]
+                    ],
+                    [
+                        "slug" => "bid",
+                        "name" => "Tender offer",
+                        "i10n" => ["sv" => "Offentligt uppköpserbjudande", 'fi' => "Julkinen ostotarjous"]
+                    ],
+                    [
+                        "slug" => "member-state",
+                        "name" => "Member state",
+                        "i10n" => ["sv" => "Hemstat", 'fi' => "Jäsenvaltio"]
+                    ],
+                    [
+                        "slug" => "nav",
+                        "name" => "Net Asset Value",
+                        "i10n" => ["sv" => "NAV kurs", 'fi' => "Substanssiarvo"]
+                    ],
+                    [
+                        "slug" => "description",
+                        "name" => "Company Description",
+                        "i10n" => ["sv" => "Företagsbeskrivning", 'fi' => "Yrityksen kuvaus"]
+                    ],
+                    [
+                        "slug" => "exdate",
+                        "name" => "Ex date",
+                        "i10n" => ["sv" => "X-datum"]
+                    ],
+                    [
                         "slug" => "shares",
                         "name" => "Shares",
                         "i10n" => ["sv" => "Aktie", 'fi' => "Osakkeet"],
@@ -313,7 +366,6 @@ function mfn_sync_taxonomy()
                                 "name" => "Rights Change",
                                 "i10n" => ["sv" => "Rättighetsförändring", 'fi' => "Oikeuksien muutos"]
                             ]
-
                         ]
                     ]
                 ]
@@ -361,6 +413,16 @@ function mfn_sync_taxonomy()
                         "i10n" => ["sv" => "Valberedning", "fi" => "Nimityskomitea"]
                     ],
                     [
+                        "slug" => "insider",
+                        "name" => "Insider Transaction",
+                        "i10n" => ["sv" => "Insynstransaktion", "fi" => "Johdon liiketoimet"]
+                    ],
+                    [
+                        "slug" => "shareholder-announcement",
+                        "name" => "Shareholder announcement",
+                        "i10n" => ["sv" => "Flaggning", "fi" => "Liputusilmoitukset"]
+                    ],
+                    [
                         "slug" => "sales",
                         "name" => "Sales",
                         "i10n" => ["sv" => "Försäljning", "fi" => "Myynti"],
@@ -375,14 +437,7 @@ function mfn_sync_taxonomy()
                     [
                         "slug" => "staff",
                         "name" => "Staff change",
-                        "i10n" => ["sv" => "Personalförändring", "fi" => "Henkilöstön muutokset"],
-                        "children" => [
-                            [
-                                "slug" => "xxo",
-                                "name" => "Executive staff changes",
-                                "i10n" => ["sv" => "Exekutiva personalförändringar", "fi" => "Johtava henkilöstö muuttuu"],
-                            ]
-                        ]
+                        "i10n" => ["sv" => "Personalförändring", "fi" => "Henkilöstön muutokset"]
                     ]
                 ]
             ]

--- a/posthook.php
+++ b/posthook.php
@@ -38,7 +38,7 @@ $wp_name = $queries["wp-name"];
 
 if ($posthook_name != $wp_name) {
     http_response_code(400);
-    die("post hook name must be the same as in options " . $posthook_name . " " . $wp_name);
+    die("post hook name must be the same as in settings");
 }
 
 // Verifying intent

--- a/text-domain.php
+++ b/text-domain.php
@@ -35,6 +35,7 @@ function mfn_get_text($key)
         'label_custom_singular_name'  => mfn_text_domain('Custom Singular Name'),
         'label_disable_archive'  => mfn_text_domain('Disable Archive'),
         'label_rewrite_post_type_slug' => mfn_text_domain('Custom Post Type Slug'),
+        'label_rewrite_taxonomy_slug' => mfn_text_domain('Custom Taxonomy Slug'),
         'label_rewrite_post_type_archive_name' => mfn_text_domain('Custom Archive Name'),
         'label_rewrite_post_type_singular_name' => mfn_text_domain('Custom Singular Name'),
         'label_language_plugin_none' => mfn_text_domain('No language plugin'),
@@ -45,9 +46,11 @@ function mfn_get_text($key)
         'label_verify_signature' => mfn_text_domain('Verify Signature'),
         'label_reset_cache' => mfn_text_domain('Reset Cache'),
         'label_enable_attachments' => mfn_text_domain('Enable Attachments Widget'),
+        'label_taxonomy_disable_cus_prefix' => mfn_text_domain('Drop Custom Tag Prefix'),
         'label_meta_box_news_item_status' => mfn_text_domain(MFN_SINGULAR_NAME . ' Status'),
         /* small */
         'small_default_mfn_news' => mfn_text_domain('(Default: ' . MFN_POST_TYPE . ')'),
+        'small_mfn-news-tag' => mfn_text_domain('(Default: ' . MFN_TAXONOMY_NAME . ')'),
         'small_default_mfn_news_item' => mfn_text_domain('(Default: ' . MFN_SINGULAR_NAME . ')'),
         'small_default_mfn_news_items' => mfn_text_domain('(Default: ' . MFN_ARCHIVE_NAME . ')'),
         'small_probably_feed_mfn_se'  => mfn_text_domain('(Probably: https://feed.mfn.se/v1)'),
@@ -70,6 +73,9 @@ function mfn_get_text($key)
         ),
         'small_enable_attachments_description' => mfn_text_domain(
             '(If enabled, our plugin will handle the listing of attachments and will bypass the default mfn-attachment footer) <strong>(Enabled by default)</strong>'
+        ),
+        'small_taxonomy_disable_cus_prefix_description' => mfn_text_domain(
+            '(If enabled, when custom tags are inserted their slug will not have the "mfn-cus-" prefix)'
         ),
         /* buttons */
         'button_unlock' => mfn_text_domain('Unlock'),
@@ -97,6 +103,9 @@ function mfn_get_text($key)
         ),
         'tooltip_rewrite_post_type_slug' => mfn_text_domain(
             'Rewrite the slug (' . MFN_POST_TYPE . ') in the URL - eg. "press-releases".'
+        ),
+        'tooltip_taxonomy_rewrite_slug' => mfn_text_domain(
+            'Rewrite the taxonomy slug (' . MFN_TAXONOMY_NAME . ') in the URL'
         ),
         'tooltip_rewrite_post_type_archive_name' => mfn_text_domain(
             'Set a custom name of the news archive page  - eg. "Press Releases".'

--- a/widgets/mfn_news_feed/class-mfn-news-feed.php
+++ b/widgets/mfn_news_feed/class-mfn-news-feed.php
@@ -93,7 +93,9 @@ class News_feed {
                         $is_disclaimer = true;
                     }
                 }
-                if ($skipcustomtags && strpos($parts[0], 'mfn-cus-') !== false) {
+                if ($skipcustomtags
+                    && (strpos($parts[1], MFN_TAG_PREFIX . '-cus-') === 0
+                        || !(strpos($parts[1], MFN_TAG_PREFIX) === 0))) {
                     continue;
                 }
                 // always skip 'pll_' slug tags


### PR DESCRIPTION
- Attempt to fix issue with polylang tags being inserted in the wrong langauge.
- Add random no-cache parameter to many admin requests (could help bypass certain types of caching)
- Option to drop custom tag slug prefix (mfn-cus-)
- Option to rewrite mfn-news-tag URL slug, similar to what we do with post type.
- Fix delete all tags for polylang
- A bit more localized tags
- Add classes "mfn-primary" and "mfn-image-primary" for attachments in the Attachments Widget
- Other fixes